### PR TITLE
PAY-13784 Fix missing sidebar menu on navigation

### DIFF
--- a/assets/redoc/redoc-custom.css
+++ b/assets/redoc/redoc-custom.css
@@ -32,3 +32,13 @@ h3{
   font-weight: bold !important;
   font-family: Roboto,sans-serif !important;
 }
+
+/* Additional CSS for the side-bar menu */
+div.menu-content {
+  position: fixed;
+}
+
+/* Additional CSS for the API documentation contents */
+div.api-content {
+  margin-left: 300px;
+}


### PR DESCRIPTION
There is a bug in ReDoc for Chrome latest version
https://github.com/Redocly/redoc/issues/1167
This change is supposed to temporarily fix it until we
migrate to the newer version of ReDoc without this bug