### PR TITLE
Make API documentation contents' width responsive

### DIFF
--- a/assets/redoc/redoc-custom.css
+++ b/assets/redoc/redoc-custom.css
@@ -33,12 +33,18 @@ h3{
   font-family: Roboto,sans-serif !important;
 }
 
-/* Additional CSS for the side-bar menu */
+
+/*
+  Sidebar menu and API documentation contents
+  fix for Chrome issue in redoc
+  https://github.com/Redocly/redoc/issues/1167
+*/
 div.menu-content {
   position: fixed;
 }
 
-/* Additional CSS for the API documentation contents */
-div.api-content {
-  margin-left: 300px;
+@media screen and (min-width: 800px) {
+  div.api-content {
+    margin-left: 300px;
+  }
 }


### PR DESCRIPTION
Made API documentation contents' width responsive

For screens with width less than 800px the sidebar menu is not shown,
that is why we don't need a margin for the API documentation then.

Also changed the comments with more proper and descriptive ones.